### PR TITLE
Adding Europa NUTS SKOS ontology to list to be imported to PMD

### DIFF
--- a/vocabs/index.json
+++ b/vocabs/index.json
@@ -81,5 +81,9 @@
     "src": "vocabs/reference-intervals-additional.nt",
     "graph": "http://gss-data.org.uk/graph/reference-intervals-additional",
     "format": "application/n-triples"
+  },
+  {
+    "src": "https://data.europa.eu/euodp/repository/ec/estat/nuts/nuts.rdf",
+    "format": "application/rdf+xml"
   }
 ]


### PR DESCRIPTION
https://github.com/GSS-Cogs/family-trade/issues/84 references NUTS codes. This PR is to ensure that the corresponding ontology metadata is included in PMD to allow navigation around the NUTS SKOS hierarchy.