### PR TITLE
Testing adding ConceptSchemes metadata to info.json

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,15 @@ pipeline {
                             pmd.drafter.deleteGraph(id, graph)
                             pmd.drafter.addData(id, "${WORKSPACE}/${vocab.src}", vocab.format, 'UTF-8', graph)
                         }
+
+                        if (vocab.conceptSchemes != null){
+                            for (conceptScheme in vocab.conceptSchemes) {
+                                def catalogMetadata = new CatalogMetadata(conceptScheme)
+                                writeFile(file: "catalogConceptSchemeMeta.ttl", text: util.getCatalogMetadata(catalogMetadata))
+                                pmd.drafter.addData(id, "${WORKSPACE}/catalogConceptSchemeMeta.ttl", "text/turtle", 'UTF-8', graph)
+                            }
+                        }
+
                         writeFile(file: "prov.ttl", text: util.jobPROV(graph))
                         pmd.drafter.addData(id, "${WORKSPACE}/prov.ttl", "text/turtle", "UTF-8", graph)
                     }

--- a/vocabs/index.json
+++ b/vocabs/index.json
@@ -1,7 +1,25 @@
 [
   {
     "src": "http://purl.org/linked-data/sdmx/2009/concept",
-    "format": "text/turtle"
+    "format": "text/turtle",
+    "conceptSchemes": [
+      {
+        "identifier": "sdmx-concept-cog",
+        "conceptSchemeUri": "http://purl.org/linked-data/sdmx/2009/concept#cog",
+        "catalogUri": "http://gss-data.org.uk/catalog/vocabularies",
+        "newIdentifierBasePath": "http://gss-data.org.uk/def/concept-scheme",
+        "label": "SDMX Content Orientated Guidelines",
+        "comment": "SDMX Content Orientated Guidelines concept scheme.",
+        "markdownDescription": "SDMX Content Orientated Guidelines concept scheme.",
+        "dtIssued": "2010-04-06T00:00:00Z",
+        "dtModified": "2016-02-06T00:00:00Z",
+        "licenseUri": "https://opensource.org/licenses/mit-license.php",
+        "creatorUri": "https://github.com/UKGovLD/publishing-statistical-data",
+        "contactPointUri": "https://github.com/UKGovLD/publishing-statistical-data/issues",
+        "publisherUri": "https://github.com/UKGovLD/publishing-statistical-data",
+        "landingPageUri": "https://github.com/UKGovLD/publishing-statistical-data/blob/master/specs/src/main/vocab/sdmx-concept.ttl"
+      }
+    ]
   }, {
     "src": "http://purl.org/linked-data/sdmx/2009/code",
     "format": "text/turtle"

--- a/vocabs/licenses.ttl
+++ b/vocabs/licenses.ttl
@@ -7,3 +7,8 @@
   rdfs:label "OGLv3" ;
   rdfs:comment "Open Government Licence for public sector information" ;
 .
+
+<https://opensource.org/licenses/mit-license.php> a dct:LicenseDocument ;
+  rdfs:label "MIT" ;
+  rdfs:comment "The MIT License" ;
+.


### PR DESCRIPTION
Attempting to fix some of the SPARQL test failures by adding orphaned ConceptSchemes to the central vocab catalogue.

https://github.com/GSS-Cogs/pmd-jenkins-library/issues/37